### PR TITLE
webssh添加启动参数--wpintvl=30 

### DIFF
--- a/keepalive.sh
+++ b/keepalive.sh
@@ -195,7 +195,7 @@ startSunPanel() {
 startWebSSH() {
   cd ${installpath}/serv00-play/webssh
   ssh_port=$(jq -r ".port" config.json)
-  cmd="nohup ./wssh --port=$ssh_port  --fbidhttp=False --xheaders=False --encoding='utf-8' --delay=10  >/dev/null 2>&1 &"
+  cmd="nohup ./wssh --port=$ssh_port  --fbidhttp=False --wpintvl=30 --xheaders=False --encoding='utf-8' --delay=10  >/dev/null 2>&1 &"
   eval "$cmd"
 }
 

--- a/start.sh
+++ b/start.sh
@@ -2819,7 +2819,7 @@ startWebSSH() {
     stopProc "wssh"
   fi
   echo "正在启动中..."
-  cmd="nohup ./wssh --port=$port --fbidhttp=False --xheaders=False --encoding='utf-8' --delay=10  $args &"
+  cmd="nohup ./wssh --port=$port --wpintvl=30 --fbidhttp=False --xheaders=False --encoding='utf-8' --delay=10  $args &"
   eval "$cmd"
   sleep 2
   if checkProcAlive wssh; then


### PR DESCRIPTION
webssh添加启动参数--wpintvl=30 ，每30s发送一次心跳，保持ssh连接，避免serv00无操作自动登出的默认时间太短。